### PR TITLE
Fixes case sensitive problem on Linux

### DIFF
--- a/src/main/java/liquibase/sdk/github/GitHubClient.java
+++ b/src/main/java/liquibase/sdk/github/GitHubClient.java
@@ -333,7 +333,7 @@ public class GitHubClient {
     public Properties getInstalledBuildProperties(String repo) throws IOException {
         GHRepository ghRepository = getRepository(repo);
         String artifactName = handleArtifactName(ghRepository.getName());
-        String m2Location = String.format("/.m2/repository/org/%s/%s/0-SNAPSHOT/%s-0-SNAPSHOT.jar", ghRepository.getOwner().getName(), artifactName, artifactName);
+        String m2Location = String.format("/.m2/repository/org/%s/%s/0-SNAPSHOT/%s-0-SNAPSHOT.jar", ghRepository.getOwner().getName().toLowerCase(), artifactName, artifactName);
         File libraryJar = new File(System.getProperty("user.home") + m2Location);
         if (!libraryJar.exists()) {
             throw new IOException(String.format("Could not find jar for %s at %s", artifactName, libraryJar.getAbsolutePath()));


### PR DESCRIPTION
After last fix, " Install snapshot liquibase" stopped working with following error on Linux:
`::notice :: Installed Snapshot Liquibase [ERROR] Failed to execute goal org.liquibase.ext:liquibase-sdk-maven-plugin:0.10.19:get-build-info (default-cli) on project liquibase-test-harness: Could not find jar for liquibase-core at /home/filipe/.m2/repository/org/Liquibase/liquibase-core/0-SNAPSHOT/liquibase-core-0-SNAPSHOT.jar -> [Help 1]`

(notice Liquibase with Capital L)

This PR fixes it.
