### PR TITLE
chore: fix for upload-artifacts@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Archive Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: liquibase-sdk-maven-plugin-test-results
           path: |
@@ -42,7 +42,7 @@ jobs:
             ./**/target/site
 
       - name: Archive Packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: liquibase-sdk-maven-plugin-artifacts
           path: target/liquibase-sdk-maven-plugin-*.jar

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
     name: Draft Release ${{ needs.setup.outputs.version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK for GPG
         uses: actions/setup-java@v2


### PR DESCRIPTION
Fix for upload-artifacts@v4: files are stored in a different way and we need to follow redirects using HttpClient (but removing the authorization) .

Also bumps actions to v4 as we are not able to build this anymore. 
