### PR TITLE
DAT-21123: use the reusable workflow from build-logic

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,105 +1,21 @@
-name: Create Draft Release
+name: Create Release
+
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version (example: 4.8.2)'
-        required: true
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
+  pull-requests: read
+  issues: read
+  statuses: read
+  actions: read
+  security-events: write
   id-token: write
-  
+
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.collect-data.outputs.version }}
-    steps:
-      - name: Collect Data
-        id: collect-data
-        uses: actions/github-script@v4
-        with:
-          script: |
-            core.setOutput("version", context.payload.inputs.version);
-
-      - run: |
-          echo "Creating version ${{ steps.collect-data.outputs.version }}"
-
-  draft-release:
-    needs: [ setup ]
-    name: Draft Release ${{ needs.setup.outputs.version }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
-
-      - name: Convert escaped newlines and set GPG key
-        run: |
-          {
-            echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
-            echo
-            echo "GPG_EOF"
-          } >> $GITHUB_ENV
-
-      - name: Set up JDK for GPG
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-          gpg-private-key: ${{ env.GPG_KEY_CONTENT }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ env.GPG_PASSPHRASE }}
-
-      - name: Create Artifacts
-        env:
-          GPG_PASSWORD: ${{ env.GPG_PASSPHRASE }}
-        run: |
-          mvn -B versions:set -DnewVersion=${{ needs.setup.outputs.version }}
-          mvn -B package
-
-          ## Extract pom
-          (cd target && unzip -j liquibase-sdk-maven-plugin-${{ needs.setup.outputs.version }}.jar META-INF/maven/org.liquibase.ext/liquibase-sdk-maven-plugin/pom.xml)
-          mv target/pom.xml target/liquibase-sdk-maven-plugin-${{ needs.setup.outputs.version }}.pom.xml
-
-          ## Sign files
-          (cd target && gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab liquibase-sdk-maven-plugin-${{ needs.setup.outputs.version }}.jar)
-          (cd target && gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab liquibase-sdk-maven-plugin-${{ needs.setup.outputs.version }}-javadoc.jar)
-          (cd target && gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab liquibase-sdk-maven-plugin-${{ needs.setup.outputs.version }}-sources.jar)
-          (cd target && gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab liquibase-sdk-maven-plugin-${{ needs.setup.outputs.version }}.pom.xml)
-
-      - name: Tag repository
-        run: |
-          git tag -f v${{ needs.setup.outputs.version }}
-          git push -f origin v${{ needs.setup.outputs.version }}
-
-      - name: Create Draft Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ needs.setup.outputs.version }}
-          draft: true
-          fail_on_unmatched_files: true
-          body: Liquibase SDK Maven Plugin ${{ needs.setup.outputs.version }}
-          generate_release_notes: true
-          files: |
-            target/*.jar
-            target/*.pom.xml
-            target/*.asc
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  create-release:
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for creating releases. The workflow is simplified by removing custom job steps and delegating the release process to a reusable workflow in the `liquibase/build-logic` repository. Additionally, the workflow is now triggered automatically on pushes to the `main` branch instead of requiring manual input.

**Workflow simplification and delegation:**

* Replaced the custom release creation jobs and steps with a single `create-release` job that uses the reusable workflow from `liquibase/build-logic/.github/workflows/create-release.yml@main` and inherits secrets.

**Trigger and permissions updates:**

* Changed the workflow trigger from manual (`workflow_dispatch` with version input) to automatic on pushes to the `main` branch.
* Updated permissions to include `pull-requests: read`, `issues: read`, `statuses: read`, `actions: read`, and `security-events: write` for broader access during the release process.