### PR TITLE
DAT-21123 : Add release drafter configuration for automated changelog generation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,52 @@
+
+name-template: 'v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+exclude-labels:
+  - 'skipReleaseNotes'
+categories:
+  - title: ':green_book: Notable Changes'
+    labels: 
+      - 'notableChanges'
+  - title: '🚀 New Features'
+    labels:
+      - 'TypeEnhancement'
+      - 'TypeTest'
+  - title: '🐛 Bug Fixes 🛠'
+    labels:
+      - 'TypeBug'
+  - title: '💥 Breaking Changes'
+    labels: 
+      - 'breakingChanges'
+  - title: '🤖 Security Driver and Other Updates'
+    collapse-after: 5
+    labels:
+      - 'sdou'
+      - 'dependencies'
+  - title: '👏 New Contributors'
+    labels:
+      - 'newContributors'  
+       
+  
+change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'patch'
+      - 'bugfix'
+      - 'sdou'
+  default: minor
+template: |
+  ## Changes
+  
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
This pull request introduces a new `.github/release-drafter.yml` configuration file to automate and standardize the release note drafting process for the repository. The configuration defines how release notes are generated, categorizes changes based on labels, and sets up templates for versioning and change logs.

Release notes automation and categorization:

* Added `.github/release-drafter.yml` to enable automatic drafting of release notes, including templates for naming releases and tagging versions.
* Configured categories for release notes based on labels (e.g., notable changes, new features, bug fixes, breaking changes, security/driver updates, and new contributors) to organize change logs for easier review.
* Set up label-based version resolution to determine whether a release is major, minor, or patch, improving semantic versioning consistency.
* Defined templates for individual change entries and the overall release note, including links to full changelogs for transparency.