### PR TITLE
DAT-21123: disable sonar option to create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,4 +18,6 @@ permissions:
 jobs:
   create-release:
     uses: liquibase/build-logic/.github/workflows/create-release.yml@main
+    with: 
+      sonar: false
     secrets: inherit


### PR DESCRIPTION
This pull request makes a minor configuration update to the GitHub Actions workflow for release creation. The change disables Sonar analysis during the release process.

* Disabled Sonar analysis by setting `sonar: false` in the `create-release` workflow configuration in `.github/workflows/create-release.yml`.