### PR TITLE
DAT-21123: Add attach artifact to release workflow

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -1,0 +1,16 @@
+name: Attach Artifact to Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+  actions: read
+  packages: write
+  id-token: write
+jobs:
+  attach-artifact-to-release:
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for attaching artifacts to releases when a pull request is closed. The workflow delegates its main job to a reusable workflow and sets up the necessary permissions.

Workflow automation:

* Added `.github/workflows/attach-artifact-release.yml` to trigger on pull request closure and attach artifacts to releases using the shared workflow `extension-attach-artifact-release.yml` from `liquibase/build-logic`.
* Configured permissions for content, actions, packages, and id-token to support the workflow's operations.