### PR TITLE
DAT-21123: Add maven-antrun-plugin to copy POM file for GPG signing and release …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,36 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Copy POM file to target directory for GPG signing and release artifact attachment.
+                 The reusable workflow extension-attach-artifact-release.yml expects the POM file
+                 to be available in target/ with the naming pattern ${artifactId}-${version}.pom
+                 for signing and uploading to GitHub releases and Maven Central.
+
+                 Note: Other Liquibase extension projects inherit this functionality from
+                 liquibase-parent-pom which uses copy-rename-maven-plugin in the coverage profile.
+                 Since this project does not use the parent POM, we implement it directly using
+                 maven-antrun-plugin. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-pom-to-target</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy file="${project.basedir}/pom.xml"
+                                      tofile="${project.build.directory}/${project.artifactId}-${project.version}.pom"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This pull request adds a new build step to the `pom.xml` to ensure the POM file is copied to the target directory with the correct naming convention. This is required for GPG signing and release artifact attachment, aligning the project with the expectations of the reusable release workflow and Maven Central publishing.

Build process improvements:

* Added a `maven-antrun-plugin` execution that copies the POM file to `target/` as `${artifactId}-${version}.pom` during the `package` phase, enabling compatibility with automated signing and release workflows.

liquibase-sdk-maven-plugin does NOT have a parent POM, so it doesn't inherit this configuration. That's why we needed to add the `maven-antrun-plugin` manually.

  Our options now:

  1. Keep the maven-antrun-plugin (what we did) - works fine, explicit and clear
  2. Use copy-rename-maven-plugin instead (matches the parent POM pattern) - more consistent with other Liquibase projects
  3. Adopt the liquibase-parent-pom - would inherit all the standard configurations
  
  cc: @filipelautert @jandroav 