### PR TITLE
Fix critical untrusted checkout vulnerability in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.after}}
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- Replace `pull_request_target` with `pull_request` in the build workflow to resolve [code scanning alert #1](https://github.com/liquibase/liquibase-sdk-maven-plugin/security/code-scanning/1)
- Remove explicit `ref` checkout of PR head SHA, which is no longer needed since `pull_request` defaults to the correct merge commit
- Prevents untrusted fork PR code from executing in a privileged context with write access and secrets (CWE-829)

## Test plan
- [ ] Verify PR-triggered builds still run correctly
- [ ] Verify push-triggered builds on main/master still work
- [ ] Confirm code scanning alert #1 is resolved after merge

Generated with Claude Code